### PR TITLE
Fix typo and Install wp-cli via composer

### DIFF
--- a/wp-install.sh
+++ b/wp-install.sh
@@ -85,7 +85,7 @@ SEP="===========================================================================
 # create the folder that will store the WordPress installation
 printf $BREATH
 echo "Creating folder $WP_DIR"
-mkdir -p WP_DIR$
+mkdir -p $WP_DIR
 
 
 printf $BREATH

--- a/wp-install.sh
+++ b/wp-install.sh
@@ -92,9 +92,8 @@ printf $BREATH
 echo "Installing wp-cli"
 printf $SEP
 # install wp-cli and make it available in PATH
-wget https://raw.githubusercontent.com/wp-cli/builds/gh-pages/phar/wp-cli.phar -P /tmp/tools/
-chmod +x /tmp/tools/wp-cli.phar && mv /tmp/tools/wp-cli.phar /tmp/tools/wp
-export PATH=$PATH:/tmp/tools:vendor/bin
+composer global require wp-cli/wp-cli --no-interaction
+export PATH="$HOME/.composer/vendor/bin:$PATH"
 
 printf $BREATH
 echo "Downloading WordPress"


### PR DESCRIPTION
- Fix typo: `mkdir -p WP_DIR$`
- Install `wp-cli` via composer, so that it can be cached